### PR TITLE
[BUGFIX] Add table name

### DIFF
--- a/src/DpsPxPayPaymentRandomAmount.php
+++ b/src/DpsPxPayPaymentRandomAmount.php
@@ -26,6 +26,7 @@ use Sunnysideup\PaymentDps\Control\DpsPxPayPaymentHandler;
 
 class DpsPxPayPaymentRandomAmount extends DpsPxPayPayment
 {
+    private static $table_name = 'DpsPxPayPaymentRandomAmount';
 
     private static $max_random_deduction = 1;
 


### PR DESCRIPTION
It is strongly recommended to define a table_name for all namespaced models. Not defining a table_name may cause generated table names to be too long and may not be supported by your current database engine. The generated naming scheme will also change when upgrading to SilverStripe 5.0 and potentially break.